### PR TITLE
Fix nginx syntax to disable error logs

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -54,7 +54,7 @@ server {
     location /favicon.ico {
       alias /srv/sysoverlord/static/favicon.ico;
       access_log off;
-      error_log off;
+      error_log /dev/null;
     }
 
     location /keybase.txt {


### PR DESCRIPTION
Setting `error_log off` will create a file named off in the directory where nginx is running.

See:
https://www.wpoven.com/tutorial/how-to-disable-nginx-logs-on-your-server/
http://nginx.org/en/docs/ngx_core_module.html#error_log